### PR TITLE
[25기 정민지] 이력서 리스트 레이아웃 구현 완료

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -5,8 +5,8 @@ import Main from './pages/Main/Main';
 import CompanyList from './pages/CompanyList/CompanyList';
 import CompanyDetail from './pages/CompanyDetail/CompanyDetail';
 import Mypage from './pages/Mypage/Mypage';
-import Resume from './pages/Resume/Resume';
 import Footer from './components/Footer/Footer';
+import ResumeList from './pages/ResumeList/ResumeList';
 
 class Routes extends React.Component {
   render() {
@@ -18,7 +18,7 @@ class Routes extends React.Component {
           <Route exact path="/wd-list" component={CompanyList} />
           <Route exact path="/wd-detail" component={CompanyDetail} />
           <Route exact path="/wd-mypage" component={Mypage} />
-          <Route exact path="/wd-resume" component={Resume} />
+          <Route exact path="/wd-resume-list" component={ResumeList} />
         </Switch>
         <Footer />
       </Router>

--- a/src/pages/Resume/Resume.js
+++ b/src/pages/Resume/Resume.js
@@ -1,7 +1,0 @@
-import React from 'react';
-
-export default class Resume extends React.Component {
-  render() {
-    return null;
-  }
-}

--- a/src/pages/ResumeList/ResumeItem/ResumeItem.js
+++ b/src/pages/ResumeList/ResumeItem/ResumeItem.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import './ResumeItem.scss';
+
+class ResumeItem extends React.Component {
+  render() {
+    return (
+      <div className="ResumeItem">
+        <div className="itemTop">
+          <h3 className="itemTitle">정민지</h3>
+          <h5 className="itemDate">2021. 10. 19</h5>
+        </div>
+        <div className="itemBottom">
+          <h5 className="itemState">
+            <span className="itemFile">한</span>작성 완료
+          </h5>
+          <i className="fas fa-ellipsis-v" />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ResumeItem;

--- a/src/pages/ResumeList/ResumeItem/ResumeItem.scss
+++ b/src/pages/ResumeList/ResumeItem/ResumeItem.scss
@@ -1,0 +1,53 @@
+@import '../../../styles/variables.scss';
+
+.ResumeItem {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 260px;
+  height: 200px;
+  margin: 10px;
+  cursor: pointer;
+  border: 1px solid $theme-color-border;
+  background-color: #ffffff;
+
+  .itemTop {
+    padding: 20px;
+
+    .itemTitle {
+      font-size: 18px;
+      font-weight: 600;
+    }
+
+    .itemDate {
+      margin-top: 10px;
+      color: rgba(0, 0, 0, 0.4);
+    }
+  }
+
+  .itemBottom {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 20px;
+    border-top: 1px solid $theme-color-border;
+
+    .itemState {
+      display: flex;
+      align-items: center;
+      font-weight: 600;
+
+      .itemFile {
+        border: 1px solid black;
+        font-size: 12px;
+        padding: 3px;
+        margin-right: 10px;
+        border-radius: 3px;
+      }
+    }
+
+    i {
+      color: rgba(0, 0, 0, 0.5);
+    }
+  }
+}

--- a/src/pages/ResumeList/ResumeList.js
+++ b/src/pages/ResumeList/ResumeList.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import ResumeItem from './ResumeItem/ResumeItem';
+import './ResumeList.scss';
+
+class ResumeList extends React.Component {
+  render() {
+    return (
+      <div className="ResumeList">
+        <div className="resumeListHeader">
+          <h3 className="headerTitle">최근 문서</h3>
+        </div>
+        <div className="resumeListBody">
+          <div className="addResume">
+            <i className="far fa-clone" />
+            <p className="addResumeText">새 이력서 작성</p>
+          </div>
+          <ResumeItem />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ResumeList;

--- a/src/pages/ResumeList/ResumeList.scss
+++ b/src/pages/ResumeList/ResumeList.scss
@@ -1,0 +1,49 @@
+@import '../../styles/variables.scss';
+
+.ResumeList {
+  height: 100vh;
+  margin-top: 50px;
+  padding: 0 190px;
+  background: $theme-background-color;
+
+  .resumeListHeader {
+    @include flex-space-between;
+    padding: 20px 10px 10px 10px;
+    font-weight: 600;
+
+    .headerIntro {
+      color: $theme-color;
+      cursor: pointer;
+      margin-right: 40px;
+    }
+  }
+
+  .resumeListBody {
+    display: flex;
+    flex-wrap: wrap;
+
+    .addResume {
+      @include flex-center;
+      flex-direction: column;
+      width: fit-content;
+      padding: 40px 75px;
+      margin: 10px;
+      cursor: pointer;
+      border: 1px solid $theme-color-border;
+      background-color: #ffffff;
+
+      i {
+        background-color: $theme-color;
+        color: #ffffff;
+        font-size: 22px;
+        padding: 25px;
+        border-radius: 50%;
+      }
+
+      .addResumeText {
+        margin-top: 30px;
+        font-weight: 600;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 이력서 리스트 레이아웃을 구현합니다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 이력서 작성 화면이 나오기 전, 새로운 이력서를 추가할 수 있고 지금까지 적은 이력서 리스트를 확인할 수 있는 이력서 리스트 레이아웃을 구현하였습니다.

![resume](https://user-images.githubusercontent.com/20683436/137870273-3495a9f6-74e2-44fe-a746-170cab14a58e.PNG)
2. 클론하는 기존 페이지에는 해당 레이아웃에 `원티드 이력서 소개`라는 버튼이 있지만, 이력서 소개 페이지는 만들지 않을 예정이므로 삭제하였습니다.
<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 레이아웃 각 컴포넌트의 크기와 마진을 맞추는데 시간이 생각보다 많이 소요되었던 것 같습니다.
- 정말 필요한 경우를 제외 하고는 bottom-up 방식을 사용하려고 노력하는데, 이번 레이아웃에서는
  어떤 부분에 width를 고정값으로 지정해주어야 하고, 어떤 부분은 bottom-up을 사용해야 할지 고민이 많이 되었습니다.

<br />

## :: 기타 질문 및 특이 사항