### PR TITLE
[25기 정민지]] 로그인에 따른 조건부 렌더링 기능 추가 및 z-index 수정

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -21,18 +21,21 @@ class Nav extends React.Component {
   };
 
   render() {
+    const TOKEN = localStorage.getItem('token');
     const { isMenuVisible } = this.state;
 
     return (
-      <div className="navContainer">
-        <h3 className="navLogo">KOOTED</h3>
+      <div className="Nav">
+        <Link className="goMain" to="/">
+          <h3 className="navLogo">KOOTED</h3>
+        </Link>
         <ul className="navMenuBar">
           <li
             className="menuItem explore"
             onMouseOver={this.handleMouseOver}
             onMouseOut={this.handleMouseOut}
           >
-            <Link to="/">탐색</Link>
+            <Link to="/wd-list">탐색</Link>
           </li>
           <li className="menuItem explore">
             <Link to="/">커리어 성장</Link>
@@ -41,7 +44,7 @@ class Nav extends React.Component {
             <Link to="/">직군별 연봉</Link>
           </li>
           <li className="menuItem explore">
-            <Link to="/">이력서</Link>
+            <Link to="/wd-resume-list">이력서</Link>
           </li>
           <li className="menuItem explore">
             <Link to="/">매치업</Link>
@@ -54,7 +57,18 @@ class Nav extends React.Component {
           </li>
         </ul>
         <i className="fas fa-search btnSearch" />
-        <button className="btnSignUp">회원가입/로그인</button>
+        {TOKEN ? (
+          <Link to="/wd-mypage">
+            <img
+              className="profileImage"
+              src="/images/MyPage/profile.png"
+              alt="userImage"
+            />
+          </Link>
+        ) : (
+          <button className="btnSignUp">회원가입/로그인</button>
+        )}
+
         <SubMenu isMenuVisible={isMenuVisible} />
       </div>
     );

--- a/src/components/Nav/Nav.scss
+++ b/src/components/Nav/Nav.scss
@@ -1,40 +1,54 @@
 @import '../../styles/variables.scss';
 
-.navContainer {
+.Nav {
   position: fixed;
   width: 100%;
   display: flex;
-  flex-direction: row;
   justify-content: center;
   align-items: center;
   top: 0;
+  z-index: 500;
   background-color: #ffffff;
   border: 1px solid $theme-color-border;
 
-  .navLogo {
-    margin-right: 50px;
-    font-size: 20px;
-    font-weight: 600;
+  .goMain {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    .navLogo {
+      margin-top: -3px;
+      margin-right: 50px;
+      font-size: 20px;
+      font-weight: 600;
+    }
   }
 
   .navMenuBar {
     display: flex;
     flex-direction: row;
     font-size: 14px;
-
     font-weight: 600;
 
     .menuItem {
       padding: 17px 20px;
 
       &:hover {
-        border-bottom: 3px solid $theme-color-border;
+        border-bottom: 3px solid $theme-color;
       }
     }
   }
 
   .btnSearch {
     margin: 0 20px;
+  }
+
+  .profileImage {
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    object-fit: cover;
+    cursor: pointer;
   }
 
   .btnSignUp {

--- a/src/components/Nav/SubMenu/SubMenu.js
+++ b/src/components/Nav/SubMenu/SubMenu.js
@@ -8,7 +8,7 @@ class SubMenu extends React.Component {
 
     return (
       <div
-        className={`subMenu ${isMenuVisible ? 'showSubMenu' : 'hideSubMenu'}`}
+        className={`SubMenu ${isMenuVisible ? 'showSubMenu' : 'hideSubMenu'}`}
       >
         <SubMenuColumn
           mainCategory="개발"

--- a/src/components/Nav/SubMenu/SubMenu.scss
+++ b/src/components/Nav/SubMenu/SubMenu.scss
@@ -1,4 +1,4 @@
-.subMenu {
+.SubMenu {
   display: flex;
   flex-direction: row;
   justify-content: center;

--- a/src/components/Nav/SubMenu/SubMenuColumn/SubMenuColumn.js
+++ b/src/components/Nav/SubMenu/SubMenuColumn/SubMenuColumn.js
@@ -5,7 +5,7 @@ class SubMenuColumn extends React.Component {
   render() {
     const { mainCategory, subCategory } = this.props;
     return (
-      <div className="columnContainer">
+      <div className="SubMenuColumn">
         <h3 className="columnHeader">
           {mainCategory}
           <i className="fas fa-chevron-right" />

--- a/src/components/Nav/SubMenu/SubMenuColumn/SubMenuColumn.scss
+++ b/src/components/Nav/SubMenu/SubMenuColumn/SubMenuColumn.scss
@@ -1,4 +1,4 @@
-.columnContainer {
+.SubMenuColumn {
   margin: 0 35px;
   cursor: pointer;
   padding: 40px 15px;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 페이지 상단에 항상 위치하는 Nav바의 레이아웃 및 기능을 구현합니다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 다른 브랜치들과 rebase 된 후 화면을 확인해보니, z-index값을 부여하지 않아 헤더가 항상 상단에 떠있어야 하는데
없어지는 문제가 발생하였습니다. 따라서 z-index 값을 추가하여 다른 레이아웃보다 위에 떠있도록 변경하였습니다.

![image](https://user-images.githubusercontent.com/20683436/138543977-6f8b6105-3098-417c-b0b4-024539758113.png)
2. 각 메뉴에 hover 하면 텍스트 아래에 선이 생기는데, 회색이어서 잘 보이지 않아 main-color로 변경하였습니다.
3. 로그인하지 않은 사용자는 `로그인/회원가입` 버튼, 로그인 한 사용자는 본인의 프로필 사진으로 조건부 렌더링 해주어야 해서, `localStorage.getItem()` 값이 존재하는지 여부로 기능을 구현하였습니다.

![image](https://user-images.githubusercontent.com/20683436/138543991-4dd2eb90-4b44-47c6-86ad-989683fb9ed9.png)
4. 로고를 누르면 메인 페이지로 이동할 수 있도록 Link를 추가하였습니다.
5. 최상단 className을 componentName과 동일하게 변경하고,  css 기본속성들은 삭제하였습니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- css 코드에서 어떤 부분이 잘못되었는지 스스로 찾아내서, 코드를 깔끔하게 정리하는 습관이 생겼습니다. 
- branch에서 작업할 때, 내가 구현하는 부분 뿐만 아니라 다른 사람들이 구현한 부분과 합쳤을 때 발생하는 이슈 
즉, 전체적인 부분을 생각해야 된다는 점을 한 번 더 깨달을 수 있었습니다.

<br />

## :: 기타 질문 및 특이 사항
- 추후에 클릭한 카테고리에 따라서 그에 알맞게 필터링된 채용 공고 리스트 페이지로 이동할 수 있도록(path parameter) 수정할 예정입니다.