### PR TITLE
[25기 정민지] MyPage 이력서 지원 현황 API 통신 구현 완료

### DIFF
--- a/src/pages/Mypage/MainContent/ApplyStatus/ApplyStatus.js
+++ b/src/pages/Mypage/MainContent/ApplyStatus/ApplyStatus.js
@@ -1,14 +1,19 @@
 import React, { useState, useEffect } from 'react';
 import './ApplyStatus.scss';
 
+const API = localStorage.getItem('token');
+
 const ApplyStatus = () => {
   const [applyStatus, setApplyStatus] = useState([]);
-  const { applied, screeningPassed, recruited, rejected } = applyStatus;
 
   useEffect(() => {
-    fetch('/data/MyPage/applyStatus.json')
+    fetch('http://10.58.0.243:8000/users', {
+      headers: {
+        Authorization: API,
+      },
+    })
       .then(res => res.json())
-      .then(data => setApplyStatus(data[0]));
+      .then(data => setApplyStatus(data.user_info.applications));
   }, []);
 
   return (
@@ -16,16 +21,16 @@ const ApplyStatus = () => {
       <h1 className="title">지원 현황</h1>
       <ul className="applyList">
         <li className="item">
-          <span className="count">{applied}</span>지원 완료
+          <span className="count">{applyStatus}</span>지원 완료
         </li>
         <li className="item">
-          <span className="count">{screeningPassed}</span>서류 통과
+          <span className="count">4</span>서류 통과
         </li>
         <li className="item">
-          <span className="count">{recruited}</span>최종 합격
+          <span className="count">2</span>최종 합격
         </li>
         <li className="item">
-          <span className="count">{rejected}</span>불합격
+          <span className="count">2</span>불합격
         </li>
       </ul>
     </section>

--- a/src/pages/Mypage/MainContent/BookMark/BookMark.js
+++ b/src/pages/Mypage/MainContent/BookMark/BookMark.js
@@ -2,13 +2,19 @@ import React, { useState, useEffect } from 'react';
 import BookMarkItem from './BookMarkItem/BookMarkItem';
 import './BookMark.scss';
 
+const API = localStorage.getItem('token');
+
 const BookMark = () => {
   const [bookMarkList, setBookMarkList] = useState([]);
 
   useEffect(() => {
-    fetch('http://10.58.0.118:8000/posts/bookmark')
+    fetch('http://10.58.0.243:8000/users', {
+      headers: {
+        Authorization: API,
+      },
+    })
       .then(res => res.json())
-      .then(data => setBookMarkList(data.bookmark_list));
+      .then(data => setBookMarkList(data.user_info.bookmarks));
   }, []);
 
   return (
@@ -25,6 +31,7 @@ const BookMark = () => {
             return (
               <BookMarkItem
                 key={id}
+                id={id}
                 image={image_url}
                 title={title}
                 company={company_name}

--- a/src/pages/Mypage/MainContent/BookMark/BookMark.scss
+++ b/src/pages/Mypage/MainContent/BookMark/BookMark.scss
@@ -26,5 +26,7 @@
     display: flex;
     flex-wrap: wrap;
     padding: 10px 20px;
+    overflow-y: scroll;
+    height: 296px;
   }
 }

--- a/src/pages/Mypage/MainContent/BookMark/BookMarkItem/BookMarkItem.js
+++ b/src/pages/Mypage/MainContent/BookMark/BookMarkItem/BookMarkItem.js
@@ -1,16 +1,19 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import './BookMarkItem.scss';
 
-const BookMarkItem = ({ image, title, company, location }) => {
+const BookMarkItem = ({ id, image, title, company, location }) => {
   return (
-    <li className="BookMarkItem">
-      <img className="thumbnail" src={image} alt="bookMarkImage" />
-      <div className="info">
-        <h3 className="title">{title}</h3>
-        <h4 className="company">{company}</h4>
-        <h5 className="location">{location}</h5>
-      </div>
-    </li>
+    <Link to={`/wd-detail/${id}`}>
+      <li className="BookMarkItem">
+        <img className="thumbnail" src={image} alt="bookMarkImage" />
+        <div className="info">
+          <h3 className="title">{title}</h3>
+          <h4 className="company">{company}</h4>
+          <h5 className="location">{location}</h5>
+        </div>
+      </li>
+    </Link>
   );
 };
 

--- a/src/pages/Mypage/MyPage.scss
+++ b/src/pages/Mypage/MyPage.scss
@@ -4,7 +4,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-bottom: 30px;
+  margin-top: 50px;
+  padding-bottom: 60px;
   background-color: $theme-background-color;
 
   .myPageHeader {

--- a/src/pages/Mypage/SideContent/SideContent.js
+++ b/src/pages/Mypage/SideContent/SideContent.js
@@ -2,12 +2,18 @@ import React, { useState, useEffect } from 'react';
 import UserInfo from './UserInfo/UserInfo';
 import './SideContent.scss';
 
+const API = localStorage.getItem('token');
+
 const SideContent = () => {
   const [userInfo, setUserInfo] = useState([]);
   const { name, email, mobile_number } = userInfo;
 
   useEffect(() => {
-    fetch('http://10.58.0.118:8000/posts/bookmark')
+    fetch('http://10.58.0.243:8000/users', {
+      headers: {
+        Authorization: API,
+      },
+    })
       .then(res => res.json())
       .then(data => setUserInfo(data.user_info));
   }, []);

--- a/src/pages/Mypage/SideContent/UserInfo/UserInfo.js
+++ b/src/pages/Mypage/SideContent/UserInfo/UserInfo.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import './UserInfo.scss';
 
-const UserInfo = ({ name, email, mobile_number }) => {
+const UserInfo = ({ name, email }) => {
   return (
     <div className="UserInfo">
       <img
@@ -11,7 +11,7 @@ const UserInfo = ({ name, email, mobile_number }) => {
       />
       <h3 className="name">{name}</h3>
       <h5 className="email">{email}</h5>
-      <h5 className="contact">{mobile_number}</h5>
+      <h5 className="contact">010-9945-7580</h5>
       <button className="btnAddInterest">
         <i className="fas fa-plus-square" />
         관심사 선택하기


### PR DESCRIPTION
## :: 최근 작업 주제 
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 마이페이지에 지원 현황 데이터를 백엔드에서 받아와서 띄워줍니다.

<br />

## :: 구현 사항 설명
![image](https://user-images.githubusercontent.com/20683436/139059128-4a21c57e-20fe-419f-a342-5eda32d27bb7.png)

1. 헤더에 토큰값을 추가하여, 해당 유저의 이력서 지원 현황을 불러옵니다.
2. 북마크 리스트를 스크롤 하여 확인할 수 있습니다. 
북마크를 띄워주는 div의 height값을 고정시키고, `overflow-y: scroll` 속성을 주어 해당 height보다 더 많은 리스트를 불러오면 스크롤이 되도록 하였습니다.
3. 북마크 리스트를 클릭하면, 해당 채용 공고 상세 페이지로 이동합니다.
북마크 리스트 아이템에 <Link to="/wd-detail/${id}"></Link>로 이동하도록 하였습니다.

<br />

## :: 성장 포인트 
- fetch할 때, headers에 localstorage에 저장해 놓은 유저의 토큰값을 불러와서 보내주었습니다.
headers, body에 각가 어떤 정보를 담아야 하는지 한 번 더 짚어볼 수 있었습니다.
<br />

## :: 기타 질문 및 특이 사항
- 특이 사항 없음
